### PR TITLE
Refactor ingestion module and add tests

### DIFF
--- a/tests/unit/test_ingestion.py
+++ b/tests/unit/test_ingestion.py
@@ -1,0 +1,44 @@
+"""Testes para o módulo de ingestão."""
+
+import pytest
+
+pyspark = pytest.importorskip("pyspark")
+from pyspark.sql import SparkSession
+
+from src.ingestion.main import save_to_parquet
+
+
+@pytest.fixture(scope="module")
+def spark_session():
+    spark = SparkSession.builder.master("local[*]").appName("tests").getOrCreate()
+    yield spark
+    spark.stop()
+
+
+def test_save_products_to_parquet(tmp_path, spark_session):
+    data = [
+        {
+            "id": 1,
+            "title": "Produto A",
+            "price": 10,
+            "description": "desc",
+            "category": "cat",
+            "image": "img",
+            "rating": {"rate": 4.5, "count": 2},
+        }
+    ]
+
+    output_path = tmp_path / "products.parquet"
+    save_to_parquet("products", data, str(output_path), spark_session)
+
+    assert output_path.exists()
+
+
+def test_save_users_to_parquet(tmp_path, spark_session):
+    data = [{"id": 1, "name": "John", "email": "john@example.com"}]
+
+    output_path = tmp_path / "users.parquet"
+    save_to_parquet("users", data, str(output_path), spark_session)
+
+    assert output_path.exists()
+


### PR DESCRIPTION
## Summary
- refactor ingestion module: cleaned imports, added typing and validation, ensured parquet write for products
- add unit tests for products and users parquet writing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688fb78e6cc48324bfb05d1e0c7c9c2f